### PR TITLE
Fixed bump-only stalling bug... I think

### DIFF
--- a/tasks/bumper.coffee
+++ b/tasks/bumper.coffee
@@ -95,6 +95,9 @@ module.exports = (grunt) ->
 
           # Allow for --force
           next()
+      else
+        next()
+
 
     globalVersion = undefined # when bumping multiple files
     gitVersion = undefined # when bumping using `git describe`


### PR DESCRIPTION
When using bump-only, the process did not continue. After some debugging, I've found that the process stalled at this point. After I added these two lines, the process continued and the version was bumped as expected. 

Sorry to add this directly to the master branch... but I guess that with this minor change you will be able to see whether or not it is valid just by looking at it. 
